### PR TITLE
fix: only cat daemon if file exists

### DIFF
--- a/.github/actions/run-tests/action.yaml
+++ b/.github/actions/run-tests/action.yaml
@@ -124,7 +124,7 @@ runs:
       if: inputs.no-setup == 'false'
       shell: bash
       run: |
-        cat /etc/docker/daemon.json
+        if [ -f /etc/docker/daemon.json ]; then cat /etc/docker/daemon.json; fi
         echo '{ "live-restore": false }' | sudo tee /etc/docker/daemon.json
         sudo systemctl reload docker
         make check-swarm-init

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   shared:
+    if: github.repository == 'pantos-io/e2e-testing'
     uses: pantos-io/ci-workflows/.github/workflows/sonar.yml@v1
     secrets: inherit
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes [some pipelines](https://github.com/jpantos/validatornode/actions/runs/12654117286/job/35261690042) failing when the daemon file is not pre-existing.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions

_Please replace this line with instructions on how to test your changes._


## [optional] Are there any post deployment tasks we need to perform?
